### PR TITLE
Add a badge for Slack signup/signin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Stories in Ready](https://badge.waffle.io/friendlycode/meeting-notes.png?label=ready&title=Ready)](https://waffle.io/friendlycode/meeting-notes)
+[![Slack Status](https://slackin-friendlycode.herokuapp.com/badge.svg)](https://slackin-friendlycode.herokuapp.com)
+
 # Meeting Notes And Agendas
 All meetings are open to everyone. Meeting notes are provided for the following events.
 


### PR DESCRIPTION
I noticed that the notes refer to Slack channels, so I figured the addition of a badge would help people find the Slack organization.
